### PR TITLE
Feat/build list

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -115,6 +115,12 @@ then
   exit 0
 fi
 
+if [ "activate_runtime" == "$action" ];
+then
+  run_activate_runtime $runtime $version
+  exit 0
+fi
+
 if [ "copy_build_package" == "$action" ];
 then
   run_copy_build_package

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -60,7 +60,7 @@ run_test() {
   return 0
 }
 
-activate_runtime() {
+run_activate_runtime() {
   runtime=$1
   version=$2
   space="  "

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -66,8 +66,13 @@ run_activate_runtime() {
   space="  "
   file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  exec_builder "-f $file && echo version: \"3.8\" > docker-compose.yml; echo $space$spaceservices: >> docker-compose.yml; echo 'Appending runtime to docker-compose.yml...'; echo ${space}${space}$runtime-$version: >> docker-compose.yml ; echo ${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version >> docker-compose.yml || echo ${space}${space}$runtime-$version: >> docker-compose.yml ; echo ${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version >> docker-compose.yml || return 1"
-  exec_builder 'cat docker-compose.yml'
+  exec_builder "-f docker-compose.yml"
+  if [[$?]]; then
+    command="echo -e version: \"3.8\"\n${space}${space}services:\n${space}${space}${space}${space}${runtime}-${version}\n${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
+  else
+    command="echo -e ${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
+  fi
+  exec_builder "$command" || return 1
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
   return 0
 }

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -66,7 +66,7 @@ run_activate_runtime() {
   space="  "
   file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  exec_builder "-f $file && echo 'version: "3.8"' > docker-compose.yml; echo "$space$spaceservices:" >> docker-compose.yml; echo "Appending runtime to docker-compose.yml..."; echo "${space}${space}$runtime-$version:" >> docker-compose.yml ; echo "${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml || echo "${space}${space}$runtime-$version:" >> docker-compose.yml ; echo "${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml || return 1"
+  exec_builder "-f $file && echo version: \"3.8\" > docker-compose.yml; echo $space$spaceservices: >> docker-compose.yml; echo 'Appending runtime to docker-compose.yml...'; echo ${space}${space}$runtime-$version: >> docker-compose.yml ; echo ${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version >> docker-compose.yml || echo ${space}${space}$runtime-$version: >> docker-compose.yml ; echo ${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version >> docker-compose.yml || return 1"
   exec_builder 'cat docker-compose.yml'
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
   return 0

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -66,19 +66,8 @@ run_activate_runtime() {
   space="  "
   file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  if [[ -f $file ]]; then
-    echo 'version: "3.8"' > docker-compose.yml
-    echo "${space}${space}services:" >> docker-compose.yml
-    echo "Appending runtime to docker-compose.yml..."
-    echo "${space}${space}$runtime-$version:" >> docker-compose.yml
-    echo "${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml
-  else
-    echo "Creating docker-compose.yml..."
-    echo "Appending runtime to docker-compose.yml..."
-    echo "${space}${space}$runtime-$version:" >> docker-compose.yml
-    echo "${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml  fi
-  fi
-  cat docker-compose.yml
+  exec_builder "-f $file && echo 'version: "3.8"' > docker-compose.yml; echo "$space$spaceservices:" >> docker-compose.yml; echo "Appending runtime to docker-compose.yml..."; echo "${space}${space}$runtime-$version:" >> docker-compose.yml ; echo "${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml || echo "${space}${space}$runtime-$version:" >> docker-compose.yml ; echo "${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml || return 1"
+  exec_builder 'cat docker-compose.yml'
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
   return 0
 }

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -63,7 +63,6 @@ run_test() {
 activate_runtime() {
   runtime=$1
   version=$2
-  build=$3
   space="  "
   echo "Activating version: $version and runtime: $runtime for build: $build"
   if test -f docker-compose.yml; then
@@ -90,7 +89,7 @@ run_deploy() {
   exec_builder "docker tag continuous:php_$version 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version"
   exec_builder "aws ecr get-login --region us-east-1 --registry-ids 310957825501 --no-include-email | bash"
   exec_builder "docker push 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version"
-  activate_runtime $runtime $version $CPHP_BUILD_ID
+  activate_runtime $runtime $version
 }
 
 action=$1

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -64,7 +64,7 @@ activate_runtime() {
   runtime=$1
   version=$2
   space="  "
-  echo "Activating version: $version and runtime: $runtime for build: $build"
+  echo "Activating runtime: $runtime on version: $version"
   if test -f docker-compose.yml; then
     echo 'version: "3.8"' > docker-compose.yml
     echo "${space}${space}services:" >> docker-compose.yml

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -64,18 +64,19 @@ activate_runtime() {
   runtime=$1
   version=$2
   space="  "
+  file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  if test -f docker-compose.yml; then
+  if [[ -f $file ]]; then
     echo 'version: "3.8"' > docker-compose.yml
     echo "${space}${space}services:" >> docker-compose.yml
     echo "Appending runtime to docker-compose.yml..."
     echo "${space}${space}$runtime-$version:" >> docker-compose.yml
-    echo "${space}${space}${space}${space}image: $CPHP_REGISTRY_ADDRESS/$runtime:$version" >> docker-compose.yml
+    echo "${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml
   else
     echo "Creating docker-compose.yml..."
     echo "Appending runtime to docker-compose.yml..."
     echo "${space}${space}$runtime-$version:" >> docker-compose.yml
-    echo "${space}${space}${space}${space}image: $CPHP_REGISTRY_ADDRESS/$runtime:$version" >> docker-compose.yml  fi
+    echo "${space}${space}${space}${space}image: 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version" >> docker-compose.yml  fi
   fi
   cat docker-compose.yml
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
@@ -89,7 +90,6 @@ run_deploy() {
   exec_builder "docker tag continuous:php_$version 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version"
   exec_builder "aws ecr get-login --region us-east-1 --registry-ids 310957825501 --no-include-email | bash"
   exec_builder "docker push 310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/$runtime:$version"
-  activate_runtime $runtime $version
 }
 
 action=$1

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -66,12 +66,10 @@ run_activate_runtime() {
   space="  "
   file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  exec_builder "test -f docker-compose.yml"
-  if [[$?]]; then
-    command="echo -e version: \"3.8\"\n${space}${space}services:\n${space}${space}${space}${space}${runtime}-${version}\n${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
-  else
-    command="echo -e ${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
-  fi
+  
+  exec_builder "test -f docker-compose.yml" && \
+  command="echo -e version: \"3.8\"\n${space}${space}services:\n${space}${space}${space}${space}${runtime}-${version}\n${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml" || \
+  command="echo -e ${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
   exec_builder "$command" || return 1
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
   return 0

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -71,6 +71,7 @@ run_activate_runtime() {
   command="echo -e version: \"3.8\"\n${space}${space}services:\n${space}${space}${space}${space}${runtime}-${version}\n${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml" || \
   command="echo -e ${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
   exec_builder "$command" || return 1
+  exec_builder "cat docker-compose.yml" || return 1
   #aws --profile runtime-containers-builder s3 cp docker-compose.yml "$BUILT_RUNTIMES_S3/docker-compose.yml"
   return 0
 }

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -66,7 +66,7 @@ run_activate_runtime() {
   space="  "
   file=docker-compose.yml
   echo "Activating runtime: $runtime on version: $version"
-  exec_builder "-f docker-compose.yml"
+  exec_builder "test -f docker-compose.yml"
   if [[$?]]; then
     command="echo -e version: \"3.8\"\n${space}${space}services:\n${space}${space}${space}${space}${runtime}-${version}\n${space}${space}${space}${space}${space}${space}image:310957825501.dkr.ecr.us-east-1.amazonaws.com/cphp/runtime/${runtime}:${version} >> docker-compose.yml"
   else


### PR DESCRIPTION
Creates a docker-compose.yml in ci script in order to store the built images in a docker-compose.yml file on a versioned s3. This will be then consumed by infra-worker ec2, in order to pull the build images. This feature is intended as a failsafe in case a new runtime container is built and the docker_pull script in infra-worker hasn't been updated.